### PR TITLE
Add responsive mobile menu

### DIFF
--- a/Kontakt.html
+++ b/Kontakt.html
@@ -21,6 +21,10 @@
       color: black;
     }
 
+    body.no-scroll {
+      overflow: hidden;
+    }
+
     header {
       background: linear-gradient(90deg, var(--blau), var(--gruen));
       padding: 10px 20px;
@@ -255,7 +259,7 @@
       <a href="mitgliedwerden.html" class="nav-link">Mitglied werden</a>
       <a href="Kontakt.html" class="nav-link active">Kontakt</a>
     </nav>
-    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
+    <button class="menu-toggle" aria-label="Menü öffnen" aria-expanded="false"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="kontakt-section">
@@ -284,13 +288,7 @@
     <p>93173 Wenzenbach | <a href="mailto:juwenzenbach@gmail.com">juwenzenbach@gmail.com</a></p>
   </footer>
 
-  <script>
-    const menuToggle = document.querySelector('.menu-toggle');
-    const nav = document.querySelector('nav');
-    menuToggle.addEventListener('click', () => {
-      nav.classList.toggle('open');
-    });
-  </script>
+  <script src="menu.js"></script>
 
   </body>
   </html>

--- a/Kontakt.html
+++ b/Kontakt.html
@@ -28,6 +28,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
+      position: relative;
     }
 
     .logo img {
@@ -39,6 +40,15 @@
       gap: 15px;
       flex-wrap: wrap;
       align-items: center;
+    }
+
+    .menu-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--weiss);
+      font-size: 1.8rem;
+      cursor: pointer;
     }
 
     nav a {
@@ -57,6 +67,37 @@
 
     nav a:hover {
       background-color: rgba(255, 255, 255, 0.1);
+    }
+
+    @media (max-width: 768px) {
+      nav {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        background: linear-gradient(90deg, var(--blau), var(--gruen));
+        width: 100%;
+        padding: 10px 0;
+        gap: 10px;
+      }
+
+      nav a {
+        padding: 10px 20px;
+      }
+
+      nav.open {
+        display: flex;
+      }
+
+      .menu-toggle {
+        display: block;
+      }
+
+      form {
+        grid-template-columns: 1fr;
+      }
     }
 
     .kontakt-section {
@@ -214,6 +255,7 @@
       <a href="mitgliedwerden.html" class="nav-link">Mitglied werden</a>
       <a href="Kontakt.html" class="nav-link active">Kontakt</a>
     </nav>
+    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="kontakt-section">
@@ -241,5 +283,14 @@
     <p>&copy; 2025 Junge Union Wenzenbach</p>
     <p>93173 Wenzenbach | <a href="mailto:juwenzenbach@gmail.com">juwenzenbach@gmail.com</a></p>
   </footer>
-</body>
-</html>
+
+  <script>
+    const menuToggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+    menuToggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  </script>
+
+  </body>
+  </html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
       color: var(--weiss);
     }
 
+    body.no-scroll {
+      overflow: hidden;
+    }
+
     header {
       background: linear-gradient(to right, #00164c, #a1bf2f);
       padding: 20px 40px;
@@ -216,7 +220,7 @@
       <a href="mitgliedwerden.html">Mitglied werden</a>
       <a href="Kontakt.html">Kontakt</a>
     </nav>
-    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
+    <button class="menu-toggle" aria-label="Menü öffnen" aria-expanded="false"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="hero">
@@ -255,13 +259,7 @@
     </p>
   </footer>
 
-  <script>
-    const menuToggle = document.querySelector('.menu-toggle');
-    const nav = document.querySelector('nav');
-    menuToggle.addEventListener('click', () => {
-      nav.classList.toggle('open');
-    });
-  </script>
+  <script src="menu.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       justify-content: space-between;
       align-items: center;
       flex-wrap: wrap;
+      position: relative;
     }
 
     .logo img {
@@ -36,6 +37,15 @@
     nav {
       display: flex;
       gap: 25px;
+    }
+
+    .menu-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--weiss);
+      font-size: 1.8rem;
+      cursor: pointer;
     }
 
     nav a {
@@ -50,6 +60,33 @@
     nav a:hover {
       background-color: rgba(255, 255, 255, 0.2);
       backdrop-filter: blur(4px);
+    }
+
+    @media (max-width: 768px) {
+      nav {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        background: linear-gradient(to right, var(--blau), var(--gruen));
+        width: 100%;
+        padding: 10px 0;
+        gap: 15px;
+      }
+
+      nav a {
+        padding: 10px 20px;
+      }
+
+      nav.open {
+        display: flex;
+      }
+
+      .menu-toggle {
+        display: block;
+      }
     }
 
     .hero {
@@ -179,6 +216,7 @@
       <a href="mitgliedwerden.html">Mitglied werden</a>
       <a href="Kontakt.html">Kontakt</a>
     </nav>
+    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="hero">
@@ -216,6 +254,14 @@
       <a href="mailto:juwenzenbach@gmail.com">juwenzenbach@gmail.com</a>
     </p>
   </footer>
+
+  <script>
+    const menuToggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+    menuToggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  </script>
 
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const menuToggle = document.querySelector('.menu-toggle');
+  const nav = document.querySelector('nav');
+
+  if (!menuToggle || !nav) return;
+
+  const toggleNav = () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+    document.body.classList.toggle('no-scroll', open);
+  };
+
+  menuToggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleNav();
+  });
+
+  nav.addEventListener('click', (e) => {
+    if (e.target.tagName === 'A') {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('no-scroll');
+    }
+  });
+
+  document.addEventListener('click', (e) => {
+    if (nav.classList.contains('open') && !nav.contains(e.target) && e.target !== menuToggle) {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('no-scroll');
+    }
+  });
+});

--- a/mitgliedwerden.html
+++ b/mitgliedwerden.html
@@ -41,6 +41,7 @@
       justify-content: space-between;
       flex-wrap: wrap;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+      position: relative;
     }
 
     .logo img {
@@ -51,6 +52,15 @@
       display: flex;
       gap: 20px;
       flex-wrap: wrap;
+    }
+
+    .menu-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: white;
+      font-size: 1.8rem;
+      cursor: pointer;
     }
 
     nav a {
@@ -65,6 +75,33 @@
     nav a.active, nav a:hover {
       background-color: rgba(255, 255, 255, 0.2);
       color: white;
+    }
+
+    @media (max-width: 768px) {
+      nav {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        background: linear-gradient(to right, #00164c, #a1bf2f);
+        width: 100%;
+        padding: 10px 0;
+        gap: 10px;
+      }
+
+      nav a {
+        padding: 10px 20px;
+      }
+
+      nav.open {
+        display: flex;
+      }
+
+      .menu-toggle {
+        display: block;
+      }
     }
 
     .hero {
@@ -186,6 +223,7 @@
     <a href="mitglied_werden.html" class="active">Mitglied werden</a>
     <a href="Kontakt.html">Kontakt</a>
   </nav>
+  <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
 </header>
 
 <section class="hero">
@@ -237,6 +275,14 @@
     if (footer) {
       footer.style.marginTop = "auto";
     }
+  });
+</script>
+
+<script>
+  const menuToggle = document.querySelector('.menu-toggle');
+  const nav = document.querySelector('nav');
+  menuToggle.addEventListener('click', () => {
+    nav.classList.toggle('open');
   });
 </script>
 

--- a/mitgliedwerden.html
+++ b/mitgliedwerden.html
@@ -21,6 +21,10 @@
       color: #111;
     }
 
+    body.no-scroll {
+      overflow: hidden;
+    }
+
     body::before {
       content: "";
       position: fixed;
@@ -223,7 +227,7 @@
     <a href="mitglied_werden.html" class="active">Mitglied werden</a>
     <a href="Kontakt.html">Kontakt</a>
   </nav>
-  <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
+  <button class="menu-toggle" aria-label="Menü öffnen" aria-expanded="false"><i class="fas fa-bars"></i></button>
 </header>
 
 <section class="hero">
@@ -278,13 +282,7 @@
   });
 </script>
 
-<script>
-  const menuToggle = document.querySelector('.menu-toggle');
-  const nav = document.querySelector('nav');
-  menuToggle.addEventListener('click', () => {
-    nav.classList.toggle('open');
-  });
-</script>
+<script src="menu.js"></script>
 
 </body>
 </html>

--- a/ueberuns.html
+++ b/ueberuns.html
@@ -35,6 +35,7 @@
       align-items: center;
       flex-wrap: wrap;
       box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+      position: relative;
     }
 
     .logo img {
@@ -44,6 +45,15 @@
     nav {
       display: flex;
       gap: 25px;
+    }
+
+    .menu-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--weiss);
+      font-size: 1.8rem;
+      cursor: pointer;
     }
 
     nav a {
@@ -58,6 +68,33 @@
     nav a:hover {
       background-color: rgba(255, 255, 255, 0.2);
       backdrop-filter: blur(4px);
+    }
+
+    @media (max-width: 768px) {
+      nav {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        background: linear-gradient(to right, var(--blau), var(--gruen));
+        width: 100%;
+        padding: 10px 0;
+        gap: 15px;
+      }
+
+      nav a {
+        padding: 10px 20px;
+      }
+
+      nav.open {
+        display: flex;
+      }
+
+      .menu-toggle {
+        display: block;
+      }
     }
 
     .hero {
@@ -215,6 +252,7 @@
       <a href="mitgliedwerden.html">Mitglied werden</a>
       <a href="Kontakt.html">Kontakt</a>
     </nav>
+    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="group-photo">
@@ -337,6 +375,15 @@
   <p style="margin: 8px 0;">
     93173 Wenzenbach | <a href="mailto:juwenzenbach@gmail.com" style="color: #a1bf2f; text-decoration: none;">juwenzenbach@gmail.com</a>
   </p>
-</footer>
-</body>
-</html>
+  </footer>
+
+  <script>
+    const menuToggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+    menuToggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  </script>
+
+  </body>
+  </html>

--- a/ueberuns.html
+++ b/ueberuns.html
@@ -27,6 +27,10 @@
       color: var(--weiss);
     }
 
+    body.no-scroll {
+      overflow: hidden;
+    }
+
     header {
       background: linear-gradient(to right, var(--blau), var(--gruen));
       padding: 20px 40px;
@@ -252,7 +256,7 @@
       <a href="mitgliedwerden.html">Mitglied werden</a>
       <a href="Kontakt.html">Kontakt</a>
     </nav>
-    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
+    <button class="menu-toggle" aria-label="Menü öffnen" aria-expanded="false"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="group-photo">
@@ -377,13 +381,7 @@
   </p>
   </footer>
 
-  <script>
-    const menuToggle = document.querySelector('.menu-toggle');
-    const nav = document.querySelector('nav');
-    menuToggle.addEventListener('click', () => {
-      nav.classList.toggle('open');
-    });
-  </script>
+  <script src="menu.js"></script>
 
   </body>
   </html>

--- a/veranstaltungen.html
+++ b/veranstaltungen.html
@@ -20,6 +20,10 @@
       color: #111;
     }
 
+    body.no-scroll {
+      overflow: hidden;
+    }
+
     body::before {
   content: "";
   position: fixed;
@@ -230,7 +234,7 @@
       <a href="mitgliedwerden.html">Mitglied werden</a>
       <a href="Kontakt.html">Kontakt</a>
     </nav>
-    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
+  <button class="menu-toggle" aria-label="Menü öffnen" aria-expanded="false"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="hero">
@@ -398,13 +402,7 @@
 
     renderKalender(aktuellesDatum);
   </script>
-  <script>
-    const menuToggle = document.querySelector('.menu-toggle');
-    const nav = document.querySelector('nav');
-    menuToggle.addEventListener('click', () => {
-      nav.classList.toggle('open');
-    });
-  </script>
+  <script src="menu.js"></script>
 </body>
 </html>
 

--- a/veranstaltungen.html
+++ b/veranstaltungen.html
@@ -40,6 +40,7 @@
       justify-content: space-between;
       flex-wrap: wrap;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+      position: relative;
     }
 
     .logo img {
@@ -50,6 +51,15 @@
       display: flex;
       gap: 20px;
       flex-wrap: wrap;
+    }
+
+    .menu-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: white;
+      font-size: 1.8rem;
+      cursor: pointer;
     }
 
     nav a {
@@ -65,6 +75,33 @@
   background-color: rgba(255, 255, 255, 0.2);
   color: white;
 }
+
+    @media (max-width: 768px) {
+      nav {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        background: linear-gradient(to right, #00164c, #a1bf2f);
+        width: 100%;
+        padding: 10px 0;
+        gap: 10px;
+      }
+
+      nav a {
+        padding: 10px 20px;
+      }
+
+      nav.open {
+        display: flex;
+      }
+
+      .menu-toggle {
+        display: block;
+      }
+    }
 
     .hero {
       background: linear-gradient(135deg, #00164c, #a1bf2f);
@@ -193,6 +230,7 @@
       <a href="mitgliedwerden.html">Mitglied werden</a>
       <a href="Kontakt.html">Kontakt</a>
     </nav>
+    <button class="menu-toggle" aria-label="Menü öffnen"><i class="fas fa-bars"></i></button>
   </header>
 
   <section class="hero">
@@ -359,6 +397,13 @@
     }
 
     renderKalender(aktuellesDatum);
+  </script>
+  <script>
+    const menuToggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+    menuToggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make navigation mobile-friendly with hamburger toggle
- hide contact form grid on narrow screens for better layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd9f7525c8328ab203e573dfa8fd3